### PR TITLE
Now the pool "allocated" counter decreases on connection close (fixes #4)

### DIFF
--- a/lib/trireme-jdbc-pool.js
+++ b/lib/trireme-jdbc-pool.js
@@ -69,7 +69,7 @@ Pool.prototype.alloc = function(cb) {
 Pool.prototype.free = function(o) {
   if (this.pool.length >= this.max) {
     // Pool full -- close!
-    closeItem(o);
+    this._closeItem(o);
 
   } else {
     resetItem(o);
@@ -91,9 +91,8 @@ Pool.prototype.free = function(o) {
   }
 };
 
-Pool.prototype.discard = function(o) {
-  closeItem(o, function() {
-  });
+Pool.prototype.discard = function(o, cb) {
+  this._closeItem(o, cb);
 };
 
 Pool.prototype.close = function(cb) {
@@ -103,7 +102,7 @@ Pool.prototype.close = function(cb) {
 function doClose(self, cb) {
   var o = self.pool.pop();
   if (o) {
-     closeItem(o, function() {
+     self._closeItem(o, function() {
        doClose(self, cb);
      });
   } else {
@@ -121,10 +120,22 @@ Pool.prototype._checkIdle = function() {
   var now = Date.now();
   while (this.pool.length > this.min) {
     if (now >= (this.pool[0]._idleTime + this.idleTimeout)) {
-      closeItem(this.pool.shift());
+      this._closeItem(this.pool.shift());
     } else {
       break;
     }
+  }
+};
+
+Pool.prototype._closeItem = function(o, cb) {
+  var self = this;
+  if (o.close) {
+    o.close(function() {
+      self.allocated--;
+      if (cb) {
+        cb();
+      }
+    });
   }
 };
 


### PR DESCRIPTION
I created a "private" prototype method for closing the connection and replaced all 4 occurrences of `closeItem()`. I covered every occurrence with an automated test.
